### PR TITLE
fix!: remove unsound container implementations

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,8 +3,11 @@
 # - https://github.com/sharkdp/bat/blob/6fc5882/.github/workflows/CICD.yml
 name: CICD
 on:
-  push: { branches: [main] }
+  push:
+    branches: [main]
+    paths-ignore: ["CHANGELOG.md"]
   pull_request:
+    paths-ignore: ["CHANGELOG.md"]
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,13 +34,14 @@ noticeable to end-users since the last release. For developers, this project fol
 
 ### Added
 
-- Implement `Emplace` for `&mut MaybeUninit<[u8; N]>` ([#PR]).
+- Implement `Emplace` for `&mut MaybeUninit<[u8; N]>` ([#2]).
 
 ### Removed
 
-- (**BREAKING**) Remove `Emplace` implementations for `&mut [u8]` and `&mut Vec<u8>` ([#PR]).
+- (**BREAKING**) Remove `Emplace` implementations for `&mut [u8; N]`, `&mut [u8]` and `&mut Vec<u8>`
+  ([#2]).
 
-[#PR]: https://github.com/loichyan/dynify/pull/PR
+[#2]: https://github.com/loichyan/dynify/pull/2
 
 ## [0.0.1] - 2025-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ noticeable to end-users since the last release. For developers, this project fol
 
 ## [Unreleased]
 
+### Added
+
+- Implement `Emplace` for `&mut MaybeUninit<[u8; N]>` ([#PR]).
+
+### Removed
+
+- (**BREAKING**) Remove `Emplace` implementations for `&mut [u8]` and `&mut Vec<u8>` ([#PR]).
+
+[#PR]: https://github.com/loichyan/dynify/pull/PR
+
 ## [0.0.1] - 2025-07-05
 
 🎉 Initial release. Check out [README](https://github.com/loichyan/dynify/blob/v0.0.1/README.md) for

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,7 @@ trybuild = "1.0.105"
 [lints.rust]
 unexpected_cfgs.level = "warn"
 unexpected_cfgs.check-cfg = ["cfg(coverage)", "cfg(coverage_nightly)"]
+unknown_lints = "allow"
+
+[lints.clippy]
+uninlined_format_args = "allow"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Here’s a quick example of how to use `dynify`:
 ```rust
 use dynify::{from_fn, Dynify, Fn};
 use std::future::Future;
+use std::mem::MaybeUninit;
 
 // `AsyncRead` is dyn incompatible :(
 trait AsyncRead {
@@ -35,8 +36,8 @@ impl<T: AsyncRead> DynAsyncRead for T {
 
 // Now we can use dynamic dispatched `AsyncRead`!
 async fn dynamic_dispatch(reader: &mut dyn DynAsyncRead) {
-    let mut stack = [0u8; 16];
-    let mut heap = Vec::<u8>::new();
+    let mut stack = [MaybeUninit::<u8>::uninit(); 16];
+    let mut heap = Vec::<MaybeUninit<u8>>::new();
     // Initialize trait objects on the stack if not too large, otherwise on the heap.
     let fut = reader.read_to_string().init2(&mut stack, &mut heap);
     let content = fut.await;

--- a/examples/async_iterator.rs
+++ b/examples/async_iterator.rs
@@ -10,11 +10,11 @@ trait Stream {
 
 trait DynStream {
     type Item;
-    fn next(&mut self) -> Fn!(&mut Self => dyn '_ + Future<Output = Option<Self::Item>>);
+    fn next(&mut self) -> Fn!(&'_ mut Self => dyn '_ + Future<Output = Option<Self::Item>>);
 }
 impl<T: Stream> DynStream for T {
     type Item = T::Item;
-    fn next(&mut self) -> Fn!(&mut Self => dyn '_ + Future<Output = Option<Self::Item>>) {
+    fn next(&mut self) -> Fn!(&'_ mut Self => dyn '_ + Future<Output = Option<Self::Item>>) {
         from_fn!(T::next, self)
     }
 }

--- a/examples/async_iterator.rs
+++ b/examples/async_iterator.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::mem::MaybeUninit;
 
 use dynify::{from_fn, Dynify, Fn};
 
@@ -31,8 +32,8 @@ where
 
 /// Validates the input with dynamic dispatched streams!
 async fn validate_data(data: &str, iter: &mut dyn DynStream<Item = char>) {
-    let mut stack = [0u8; 16];
-    let mut heap = vec![0u8; 0];
+    let mut stack = [MaybeUninit::<u8>::uninit(); 16];
+    let mut heap = Vec::<MaybeUninit<u8>>::new();
     let mut data_iter = data.chars();
 
     while let Some(ch) = iter.next().init2(&mut stack, &mut heap).await {

--- a/src/constructor.rs
+++ b/src/constructor.rs
@@ -251,9 +251,10 @@ pub trait Dynify: Construct {
     /// ```rust
     /// # use dynify::{from_fn, Dynify, Fn};
     /// # use std::future::Future;
+    /// # use std::mem::MaybeUninit;
     /// # pollster::block_on(async {
-    /// let mut stack = [0u8; 32];
-    /// let mut heap = vec![0u8; 0];
+    /// let mut stack = MaybeUninit::<[u8; 16]>::uninit();
+    /// let mut heap = Vec::<MaybeUninit<u8>>::new();
     ///
     /// let constructor: Fn!(=> dyn Future<Output = i32>) = from_fn!(|| async { 777 });
     /// let ret = constructor.init2(&mut stack, &mut heap).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 #![cfg_attr(not(test), no_std)]
 #![allow(unsafe_op_in_unsafe_fn)]
-#![allow(unknown_lints)]
 #![deny(clippy::unsound_collection_transmute)]
 
 #[cfg(feature = "alloc")]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -25,6 +25,7 @@ pub(crate) fn defer<F: FnOnce()>(f: F) -> Defer<F> {
 #[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod test_utils {
+    use core::mem::MaybeUninit;
     use std::any::Any;
     use std::cell::Cell;
     use std::fmt;
@@ -60,14 +61,22 @@ mod test_utils {
         arr
     }
 
+    pub(crate) fn newstk<const N: usize>() -> [MaybeUninit<u8>; N] {
+        [MaybeUninit::uninit(); N]
+    }
+
     pub(crate) fn randstr(len: impl RangeBounds<usize>) -> String {
         std::iter::repeat_with(fastrand::alphanumeric)
             .take(fastrand::usize(len))
             .collect()
     }
 
-    pub(crate) fn boxed_slice(len: usize) -> Box<[u8]> {
-        vec![0; len].into_boxed_slice()
+    pub(crate) fn newheap(len: usize) -> Vec<MaybeUninit<u8>> {
+        vec![MaybeUninit::uninit(); len]
+    }
+
+    pub(crate) fn newheap_fixed(len: usize) -> Box<[MaybeUninit<u8>]> {
+        newheap(len).into_boxed_slice()
     }
 }
 #[cfg(test)]

--- a/tests/ui/buffered_mut_borrow_twice_fail.rs
+++ b/tests/ui/buffered_mut_borrow_twice_fail.rs
@@ -2,7 +2,7 @@ use dynify::{from_closure, Buffered, Dynify};
 
 // `Buffered` holds mutable reference exclusively
 fn main() {
-    let mut stack = [0u8; 16];
+    let mut stack = std::mem::MaybeUninit::<[u8; 16]>::uninit();
     let init1 = from_closure(|slot| slot.write(123));
     let init2 = from_closure(|slot| slot.write(456));
 

--- a/tests/ui/pinned_buffered_unpin_fail.rs
+++ b/tests/ui/pinned_buffered_unpin_fail.rs
@@ -1,11 +1,10 @@
 use std::marker::PhantomPinned;
-use std::ops::Deref;
 use std::pin::Pin;
 
 use dynify::{from_closure, Buffered, Dynify};
 
 // Wraps Pin::into_inner to prevent rustc from reporting errors from rust-src.
-fn unpin<P: Deref>(ptr: Pin<P>) -> P
+fn unpin<P: std::ops::Deref>(ptr: Pin<P>) -> P
 where
     P::Target: Unpin,
 {
@@ -13,7 +12,7 @@ where
 }
 
 fn main() {
-    let mut stack = [0u8; 16];
+    let mut stack = std::mem::MaybeUninit::<[u8; 16]>::uninit();
     let init = from_closure(|slot| slot.write(PhantomPinned));
     let val: Buffered<PhantomPinned> = init.init(&mut stack);
 

--- a/tests/ui/pinned_buffered_unpin_fail.stderr
+++ b/tests/ui/pinned_buffered_unpin_fail.stderr
@@ -1,7 +1,7 @@
 error[E0277]: `PhantomPinned` cannot be unpinned
-  --> tests/ui/pinned_buffered_unpin_fail.rs:21:19
+  --> tests/ui/pinned_buffered_unpin_fail.rs:20:19
    |
-21 |     let _ = unpin(pinned); // fails
+20 |     let _ = unpin(pinned); // fails
    |             ----- ^^^^^^ the trait `Unpin` is not implemented for `Buffered<'_, PhantomPinned>`
    |             |
    |             required by a bound introduced by this call
@@ -9,16 +9,16 @@ error[E0277]: `PhantomPinned` cannot be unpinned
    = note: the trait bound `Buffered<'_, PhantomPinned>: Unpin` is not satisfied
    = note: required for `Buffered<'_, PhantomPinned>` to implement `Unpin`
 note: required by a bound in `unpin`
-  --> tests/ui/pinned_buffered_unpin_fail.rs:10:16
+  --> tests/ui/pinned_buffered_unpin_fail.rs:9:16
    |
-8  | fn unpin<P: Deref>(ptr: Pin<P>) -> P
+7  | fn unpin<P: std::ops::Deref>(ptr: Pin<P>) -> P
    |    ----- required by a bound in this function
-9  | where
-10 |     P::Target: Unpin,
+8  | where
+9  |     P::Target: Unpin,
    |                ^^^^^ required by this bound in `unpin`
 help: consider borrowing here
    |
-21 |     let _ = unpin(&pinned); // fails
+20 |     let _ = unpin(&pinned); // fails
    |                   +
-21 |     let _ = unpin(&mut pinned); // fails
+20 |     let _ = unpin(&mut pinned); // fails
    |                   ++++


### PR DESCRIPTION
Implementations of `Emplace` for `&mut [u8; N]`, `&mut [u8]` and `&mut Vec<u8>` make it possible to observe uninitialized data in safe Rust, as shown below:

```rust
use std::mem::MaybeUninit;
use dynify::Dynify;

let mut stack = [0u8; 16];
let init = dynify::from_closure(|slot| slot.write(MaybeUninit::<usize>::uninit()));
let _ = init.init(&mut stack);
for b in stack.iter() {
    println!("{}", *b); // undefined behavior!
}
```
This PR removes these  implementations. Thanks to u/SkiFire13 and u/Darksonn for pointing this out (see the [original comment](https://www.reddit.com/r/rust/comments/1lrxvb1/comment/n1forar)).

This PR also implements `Emplace` for `MaybeUninit<[u8; N]>` as suggested by u/SkiFire13.
