### PR TITLE
fix: not dealloc dangling pointers

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -294,8 +294,11 @@ mod __alloc {
 
                 // Recycle the allocated memory to prevent memory leaks if
                 // `construct()` panics.
-                let clean_on_panic =
-                    crate::utils::defer(|| alloc::alloc::dealloc(ptr.as_ptr(), layout));
+                let clean_on_panic = crate::utils::defer(|| {
+                    if layout.size() != 0 {
+                        alloc::alloc::dealloc(ptr.as_ptr(), layout)
+                    }
+                });
                 let init = constructor.construct(slot);
                 validate_slot(ptr, layout, init);
 

--- a/src/container_tests.rs
+++ b/src/container_tests.rs
@@ -155,3 +155,15 @@ fn default_pin_emplace() {
     let out = Boxed.pin_emplace(init).unwrap();
     assert_eq!(out.downcast_ref::<[u8; 16]>(), Some(&inp));
 }
+
+#[test]
+#[should_panic = "just panic"]
+fn clean_up_boxed_zst_on_panic() {
+    let _ = from_closure::<(), (), _>(|_| panic!("just panic")).boxed();
+}
+
+#[test]
+#[should_panic = "just panic"]
+fn clean_up_boxed_on_panic() {
+    let _ = from_closure::<usize, usize, _>(|_| panic!("just panic")).boxed();
+}


### PR DESCRIPTION
For boxed ZSTs, stop deallocating slot pointers since they are dangling.