### PR TITLE
refactor: add `#[must_use]` for some types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ noticeable to end-users since the last release. For developers, this project fol
 
 ### Added
 
-- (**breaking**) Always place breaking changes at the top.
+- (**BREAKING**) Always place breaking changes at the top.
 - Append other changes in chronological order under the relevant subsections.
 
 ### Changed
@@ -36,11 +36,18 @@ noticeable to end-users since the last release. For developers, this project fol
 
 - Implement `Emplace` for `&mut MaybeUninit<[u8; N]>` ([#2]).
 
+### Changed
+
+- Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` (#PRNUM).
+
 ### Removed
 
 - (**BREAKING**) Remove `Emplace` implementations for `&mut [u8; N]`, `&mut [u8]` and `&mut Vec<u8>`
   ([#2]).
 
+- Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` (#PRNUM).
+
+[#PRNUM]: https://github.com/loichyan/dynify/pull/PRNUM
 [#2]: https://github.com/loichyan/dynify/pull/2
 
 ## [0.0.1] - 2025-07-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,16 +38,16 @@ noticeable to end-users since the last release. For developers, this project fol
 
 ### Changed
 
-- Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` (#PRNUM).
+- Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` (#4).
 
 ### Removed
 
 - (**BREAKING**) Remove `Emplace` implementations for `&mut [u8; N]`, `&mut [u8]` and `&mut Vec<u8>`
   ([#2]).
 
-- Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` (#PRNUM).
+- Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` (#4).
 
-[#PRNUM]: https://github.com/loichyan/dynify/pull/PRNUM
+[#4]: https://github.com/loichyan/dynify/pull/4
 [#2]: https://github.com/loichyan/dynify/pull/2
 
 ## [0.0.1] - 2025-07-05

--- a/src/closure.rs
+++ b/src/closure.rs
@@ -5,6 +5,7 @@ use core::ptr::NonNull;
 use crate::constructor::{Construct, Opaque, PinConstruct, Slot};
 
 /// The constructor created by [`from_closure`].
+#[must_use = "constructor must be initialized"]
 pub struct Closure<T, F>(F, PhantomData<T>);
 // SAFETY:
 // - A typed slot only accepts writes of objects of type `T`, ensuring that the

--- a/src/constructor.rs
+++ b/src/constructor.rs
@@ -111,6 +111,7 @@ unsafe impl<T: PinConstruct> PinConstruct for &'_ mut Option<T> {
 unsafe impl<T: Construct> Construct for &'_ mut Option<T> {}
 
 /// A memory block used to store arbitrary objects.
+#[must_use = "slot must be consumed"]
 pub struct Slot<'a, T: ?Sized = Void>(NonNull<T>, PhantomData<&'a mut T>);
 impl<'a> Slot<'a> {
     /// Creates a new slot from the supplied pointer.

--- a/src/function.rs
+++ b/src/function.rs
@@ -6,6 +6,7 @@ use crate::constructor::{Construct, Opaque, PinConstruct, Slot};
 use crate::receiver::Receiver;
 
 /// A constructor for the return type of functions.
+#[must_use = "constructor must be initialized"]
 pub struct Fn<Args, Ret: ?Sized> {
     layout: Layout,
     init: unsafe fn(Slot, Args) -> &mut Opaque<Ret>,

--- a/tests/ui/from_closure_coercion_pass.rs
+++ b/tests/ui/from_closure_coercion_pass.rs
@@ -2,5 +2,5 @@ use std::any::Any;
 
 fn main() {
     let var = String::from("abc");
-    dynify::from_closure(move |slot| slot.write(var) as &mut dynify::Opaque<dyn Any>);
+    let _ = dynify::from_closure(move |slot| slot.write(var) as &mut dynify::Opaque<dyn Any>);
 }

--- a/tests/ui/from_closure_leak_slot_fail.rs
+++ b/tests/ui/from_closure_leak_slot_fail.rs
@@ -1,6 +1,6 @@
 fn main() {
     let mut slot_leaked = None;
-    dynify::from_closure::<(), (), _>(|slot| {
+    let _ = dynify::from_closure::<(), (), _>(|slot| {
         slot_leaked = Some(slot);
         unreachable!();
     });

--- a/tests/ui/from_closure_leak_slot_fail.rs
+++ b/tests/ui/from_closure_leak_slot_fail.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let mut slot_leaked = None;
+    dynify::from_closure::<(), (), _>(|slot| {
+        slot_leaked = Some(slot);
+        unreachable!();
+    });
+}

--- a/tests/ui/from_closure_leak_slot_fail.stderr
+++ b/tests/ui/from_closure_leak_slot_fail.stderr
@@ -1,0 +1,9 @@
+error[E0521]: borrowed data escapes outside of closure
+ --> tests/ui/from_closure_leak_slot_fail.rs:4:9
+  |
+2 |     let mut slot_leaked = None;
+  |         --------------- `slot_leaked` declared here, outside of the closure body
+3 |     dynify::from_closure::<(), (), _>(|slot| {
+  |                                        ---- `slot` is a reference that is only valid in the closure body
+4 |         slot_leaked = Some(slot);
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^ `slot` escapes the closure body here

--- a/tests/ui/from_closure_leak_slot_fail.stderr
+++ b/tests/ui/from_closure_leak_slot_fail.stderr
@@ -3,7 +3,7 @@ error[E0521]: borrowed data escapes outside of closure
   |
 2 |     let mut slot_leaked = None;
   |         --------------- `slot_leaked` declared here, outside of the closure body
-3 |     dynify::from_closure::<(), (), _>(|slot| {
-  |                                        ---- `slot` is a reference that is only valid in the closure body
+3 |     let _ = dynify::from_closure::<(), (), _>(|slot| {
+  |                                                ---- `slot` is a reference that is only valid in the closure body
 4 |         slot_leaked = Some(slot);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^ `slot` escapes the closure body here

--- a/tests/ui/from_closure_wrong_type_fail.rs
+++ b/tests/ui/from_closure_wrong_type_fail.rs
@@ -1,3 +1,3 @@
 fn main() {
-    dynify::from_closure(|slot| slot.write(123i32) as &mut dynify::Opaque<u32>);
+    let _ = dynify::from_closure(|slot| slot.write(123i32) as &mut dynify::Opaque<u32>);
 }

--- a/tests/ui/from_closure_wrong_type_fail.stderr
+++ b/tests/ui/from_closure_wrong_type_fail.stderr
@@ -1,5 +1,5 @@
 error[E0605]: non-primitive cast: `&mut Opaque<i32>` as `&mut Opaque<u32>`
- --> tests/ui/from_closure_wrong_type_fail.rs:2:33
+ --> tests/ui/from_closure_wrong_type_fail.rs:2:41
   |
-2 |     dynify::from_closure(|slot| slot.write(123i32) as &mut dynify::Opaque<u32>);
-  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object
+2 |     let _ = dynify::from_closure(|slot| slot.write(123i32) as &mut dynify::Opaque<u32>);
+  |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ an `as` expression can only be used to convert between primitive types or to coerce to a specific trait object

--- a/tests/ui/from_fn_with_closure_fail.stderr
+++ b/tests/ui/from_fn_with_closure_fail.stderr
@@ -13,7 +13,7 @@ note: expected fn pointer, found closure
 3 |     dynify::from_fn!(move || var);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: expected fn pointer `fn(dynify::function::MustNotBeClosure) -> {closure@$DIR/tests/ui/from_fn_with_closure_fail.rs:3:22: 3:29}`
-                found closure `{closure@$DIR/src/function.rs:186:17: 186:18}`
+                found closure `{closure@$DIR/src/function.rs:187:17: 187:18}`
 note: closures can only be coerced to `fn` types if they do not capture any variables
  --> tests/ui/from_fn_with_closure_fail.rs:3:30
   |
@@ -25,7 +25,7 @@ note: expected fn pointer, found closure
 3 |     dynify::from_fn!(move || var);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   = note: expected fn pointer `for<'a> unsafe fn(Slot<'a>, ()) -> &'a mut Opaque<_>`
-                found closure `{closure@$DIR/src/function.rs:188:17: 188:37}`
+                found closure `{closure@$DIR/src/function.rs:189:17: 189:37}`
 note: closures can only be coerced to `fn` types if they do not capture any variables
  --> tests/ui/from_fn_with_closure_fail.rs:3:30
   |


### PR DESCRIPTION
`Slot`s and constructors are expected to be consumed and should therefore be annotated with `#[must_use]`.