### PR TITLE
fix: make checks without default features pass

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -89,8 +89,14 @@ jobs:
       - name: Check | Clippy
         run: cargo clippy --locked
 
+      - name: Check | Clippy without default features
+        run: cargo clippy --locked --no-default-features
+
+      - name: Check | Clippy with all features
+        run: cargo clippy --locked --all-features
+
       - name: Check | Test suite
-        run: cargo test --locked
+        run: cargo test --locked --all-features
 
       - name: Check | Build
         run: cargo build --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,14 +38,14 @@ noticeable to end-users since the last release. For developers, this project fol
 
 ### Changed
 
-- Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` (#4).
+- Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` ([#4]).
 
 ### Removed
 
 - (**BREAKING**) Remove `Emplace` implementations for `&mut [u8; N]`, `&mut [u8]` and `&mut Vec<u8>`
   ([#2]).
 
-- Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` (#4).
+- Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` ([#4]).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ noticeable to end-users since the last release. For developers, this project fol
 
 - Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` (#4).
 
+### Fixed
+
+- Make the compilation passes when `default-features = false` (#5).
+
+[#5]: https://github.com/loichyan/dynify/pull/5
 [#4]: https://github.com/loichyan/dynify/pull/4
 [#2]: https://github.com/loichyan/dynify/pull/2
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Add dyn compatible variant to your async trait with dynify!
 
 ## ✨ Overview
 
-`dynify` implements partial features of the experimental
+dynify implements partial features of the experimental
 [in-place initialization proposal](https://github.com/rust-lang/lang-team/issues/336) in stable
 Rust, along with a set of safe APIs for creating in-place constructors to initialize trait objects.
-Here’s a quick example of how to use `dynify`:
+Here’s a quick example of how to use dynify:
 
 ```rust
 use dynify::{from_fn, Dynify, Fn};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,12 +25,17 @@ pub use self::container::{Buffered, Emplace, OutOfCapacity, PinEmplace};
 #[doc(hidden)]
 pub mod r#priv {
     pub use crate::function::{from_bare_fn, from_method, Fn};
-    pub use crate::receiver::{ArcSelf, BoxSelf, RcSelf, Receiver, RefMutSelf, RefSelf};
+    #[cfg(feature = "alloc")]
+    pub use crate::receiver::{ArcSelf, BoxSelf, RcSelf};
+    pub use crate::receiver::{Receiver, RefMutSelf, RefSelf};
 
     pub type PinRefSelf<'a> = crate::receiver::Pin<RefSelf<'a>>;
     pub type PinRefMutSelf<'a> = crate::receiver::Pin<RefMutSelf<'a>>;
+    #[cfg(feature = "alloc")]
     pub type PinBoxSelf = crate::receiver::Pin<BoxSelf>;
+    #[cfg(feature = "alloc")]
     pub type PinRcSelf = crate::receiver::Pin<RcSelf>;
+    #[cfg(feature = "alloc")]
     pub type PinArcSelf = crate::receiver::Pin<ArcSelf>;
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use core::mem::ManuallyDrop;
 
 pub enum Void {}


### PR DESCRIPTION
Not export types that required `feature = "alloc"` so as to make the compilation passes when `default-features = false`.