### PR TITLE
release: v0.1.0

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -124,7 +124,7 @@ jobs:
           release_tag: ${{ steps.configure.outputs.tag }}
           release_body: ${{ github.event.pull_request.body }}
         run: |
-          if gh release view --json="" "$release_tag" &>/dev/null; then
+          if gh release view "$release_tag" &>/dev/null; then
             echo "update existed release $release_tag"
             command=edit
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,6 @@ prevent further issues. Consequently, it includes few changes.
 
 - (**BREAKING**) Remove `Emplace` implementations for `&mut [u8; N]`, `&mut [u8]` and `&mut Vec<u8>`
   ([#2]).
-- Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` ([#4]).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ noticeable to end-users since the last release. For developers, this project fol
 
 ## [Unreleased]
 
+## [0.1.0] - 2025-07-06
+
 ### Added
 
 - Implement `Emplace` for `&mut MaybeUninit<[u8; N]>` ([#2]).
@@ -62,5 +64,6 @@ noticeable to end-users since the last release. For developers, this project fol
 🎉 Initial release. Check out [README](https://github.com/loichyan/dynify/blob/v0.0.1/README.md) for
 more details.
 
-[Unreleased]: https://github.com/loichyan/dynify/compare/v0.0.1..HEAD
+[Unreleased]: https://github.com/loichyan/dynify/compare/v0.1.0..HEAD
+[0.1.0]: https://github.com/loichyan/dynify/releases/tag/v0.1.0
 [0.0.1]: https://github.com/loichyan/dynify/releases/tag/v0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ noticeable to end-users since the last release. For developers, this project fol
 
 ## [0.1.0] - 2025-07-06
 
+The main purpose of this release is to address unsoundness and introduce breaking changes early to
+prevent further issues. Consequently, it includes few changes.
+
 ### Added
 
 - Implement `Emplace` for `&mut MaybeUninit<[u8; N]>` ([#2]).
@@ -47,7 +50,6 @@ noticeable to end-users since the last release. For developers, this project fol
 
 - (**BREAKING**) Remove `Emplace` implementations for `&mut [u8; N]`, `&mut [u8]` and `&mut Vec<u8>`
   ([#2]).
-
 - Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` ([#4]).
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "dynify"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "fastrand",
  "pollster",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dynify"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Loi Chyan <loichyan@foxmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
The main purpose of this release is to address unsoundness and introduce breaking changes early to prevent further issues. Consequently, it includes few changes.

### Added

- Implement `Emplace` for `&mut MaybeUninit<[u8; N]>` ([#2]).
- Implement `Emplace` for `SmallVec` ([#6]).

### Changed

- Add `#[must_use]` for `Slot`, `from_fn!()` and `from_closure()` ([#4]).

### Removed

- (**BREAKING**) Remove `Emplace` implementations for `&mut [u8; N]`, `&mut [u8]` and `&mut Vec<u8>` ([#2]).

### Fixed

- Make the compilation passes when `default-features = false` ([#5]).

[#6]: https://github.com/loichyan/dynify/pull/6
[#5]: https://github.com/loichyan/dynify/pull/5
[#4]: https://github.com/loichyan/dynify/pull/4
[#2]: https://github.com/loichyan/dynify/pull/2
