### PR TITLE
feat: support unwrapping `Buffered`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ noticeable to end-users since the last release. For developers, this project fol
 
 ### Added
 
-- Support downcasting a `Buffered` pointer (#10).
+- Support downcasting a `Buffered` pointer ([#10]).
 
 [#10]: https://github.com/loichyan/dynify/pull/10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,10 @@ noticeable to end-users since the last release. For developers, this project fol
 ### Added
 
 - Support downcasting a `Buffered` pointer ([#10]).
+- Support unwrapping a `Buffered` pointer ([#11]).
 
 [#10]: https://github.com/loichyan/dynify/pull/10
+[#11]: https://github.com/loichyan/dynify/pull/11
 
 ## [0.1.0] - 2025-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,16 +63,16 @@ prevent further issues. Consequently, it includes few changes.
 
 - Make the compilation passes when `default-features = false` ([#5]).
 
-[#6]: https://github.com/loichyan/dynify/pull/6
-[#5]: https://github.com/loichyan/dynify/pull/5
-[#4]: https://github.com/loichyan/dynify/pull/4
 [#2]: https://github.com/loichyan/dynify/pull/2
+[#4]: https://github.com/loichyan/dynify/pull/4
+[#5]: https://github.com/loichyan/dynify/pull/5
+[#6]: https://github.com/loichyan/dynify/pull/6
 
 ## [0.0.1] - 2025-07-05
 
 🎉 Initial release. Check out [README](https://github.com/loichyan/dynify/blob/v0.0.1/README.md) for
 more details.
 
-[Unreleased]: https://github.com/loichyan/dynify/compare/v0.1.0..HEAD
-[0.1.0]: https://github.com/loichyan/dynify/releases/tag/v0.1.0
 [0.0.1]: https://github.com/loichyan/dynify/releases/tag/v0.0.1
+[0.1.0]: https://github.com/loichyan/dynify/releases/tag/v0.1.0
+[Unreleased]: https://github.com/loichyan/dynify/compare/v0.1.0..HEAD

--- a/src/container.rs
+++ b/src/container.rs
@@ -144,6 +144,12 @@ impl<'a, T: ?Sized> Buffered<'a, T> {
         }
     }
 }
+impl<'a, T> Buffered<'a, T> {
+    /// Consumes this instance, returning the inner value.
+    pub fn into_inner(self) -> T {
+        unsafe { self.into_raw().read() }
+    }
+}
 impl<'a> Buffered<'a, dyn Any> {
     /// Attempts to downcast the pointer to a concrete type.
     pub fn downcast<T: Any>(self) -> Result<Buffered<'a, T>, Self> {

--- a/src/container_tests.rs
+++ b/src/container_tests.rs
@@ -191,15 +191,18 @@ where
     let init = from_closure(|slot| slot.write(data.clone()) as &mut Opaque<dyn Any>);
     let val = stack.emplace(init).unwrap();
     let val = val.downcast::<Impossbile>().err().unwrap();
-    assert_eq!(val.downcast().ok().as_deref(), Some(&data));
+    let val = val.downcast().ok().map(Buffered::into_inner);
+    assert_eq!(val, Some(data.clone()));
 
     let init = from_closure(|slot| slot.write(data.clone()) as &mut Opaque<dyn Any + Send>);
     let val = stack.emplace(init).unwrap();
     let val = val.downcast::<Impossbile>().err().unwrap();
-    assert_eq!(val.downcast().ok().as_deref(), Some(&data));
+    let val = val.downcast().ok().map(Buffered::into_inner);
+    assert_eq!(val, Some(data.clone()));
 
     let init = from_closure(|slot| slot.write(data.clone()) as &mut Opaque<dyn Any + Send + Sync>);
     let val = stack.emplace(init).unwrap();
     let val = val.downcast::<Impossbile>().err().unwrap();
-    assert_eq!(val.downcast().ok().as_deref(), Some(&data));
+    let val = val.downcast().ok().map(Buffered::into_inner);
+    assert_eq!(val, Some(data.clone()));
 }


### PR DESCRIPTION
Add `Buffered::into_inner`, useful for obtaining the owned value after downcasting.