### PR TITLE
feat(macros): support transformation of a function for `#[dynify]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,12 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 - Support downcasting a `Buffered` pointer ([#10]).
 - Support unwrapping a `Buffered` pointer ([#11]).
 - Add a helper macro `#[dynify]` for trait transformations ([#12]).
+- Support transformation of a function for `#[dynify]` ([#{{PRNUM}}])
 
 [#10]: https://github.com/loichyan/dynify/pull/10
 [#11]: https://github.com/loichyan/dynify/pull/11
 [#12]: https://github.com/loichyan/dynify/pull/12
+[#{{PRNUM}}]: https://github.com/loichyan/dynify/pull/{{PRNUM}}
 
 ## [0.1.0] - 2025-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,12 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 - Support downcasting a `Buffered` pointer ([#10]).
 - Support unwrapping a `Buffered` pointer ([#11]).
 - Add a helper macro `#[dynify]` for trait transformations ([#12]).
-- Support transformation of a function for `#[dynify]` ([#{{PRNUM}}])
+- Support transformation of a function for `#[dynify]` ([#13])
 
 [#10]: https://github.com/loichyan/dynify/pull/10
 [#11]: https://github.com/loichyan/dynify/pull/11
 [#12]: https://github.com/loichyan/dynify/pull/12
-[#{{PRNUM}}]: https://github.com/loichyan/dynify/pull/{{PRNUM}}
+[#13]: https://github.com/loichyan/dynify/pull/13
 
 ## [0.1.0] - 2025-07-06
 

--- a/macros/src/dynify_tests.rs
+++ b/macros/src/dynify_tests.rs
@@ -79,6 +79,19 @@ define_macro_tests!(
         quote!(MyDynTrait),
         quote!(trait Trait { async fn test(&self); }),
     )]
+    // == Functions == //
+    #[case::fn_returning_impl(
+        quote!(),
+        quote!(fn test() -> impl core::any::Any { todo!() }),
+    )]
+    #[case::fn_returning_async(
+        quote!(),
+        quote!(async fn test(_arg1: &str) -> String { todo!() }),
+    )]
+    #[case::fn_renamed(
+        quote!(my_dyn_test),
+        quote!(async fn test(_arg1: &str) -> String { todo!() }),
+    )]
     fn ui(#[case] test_name: &str, #[case] attr: TokenStream, #[case] input: TokenStream) {
         let output = expand(attr, input).unwrap();
         // Append `fn main() {}` so that they can pass compile tests

--- a/macros/src/dynify_tests/fn_renamed.rs
+++ b/macros/src/dynify_tests/fn_renamed.rs
@@ -1,0 +1,17 @@
+/* This file is @generated for testing purpose */
+#[allow(async_fn_in_trait)]
+async fn test(_arg1: &str) -> String {
+    todo!()
+}
+fn my_dyn_test<'_arg1, 'dynify>(
+    _arg1: &'_arg1 str,
+) -> ::dynify::r#priv::Fn<
+    (&'_arg1 str,),
+    dyn 'dynify + ::core::future::Future<Output = String>,
+>
+where
+    '_arg1: 'dynify,
+{
+    ::dynify::__from_fn!([] test, _arg1,)
+}
+fn main() {}

--- a/macros/src/dynify_tests/fn_returning_async.rs
+++ b/macros/src/dynify_tests/fn_returning_async.rs
@@ -1,0 +1,17 @@
+/* This file is @generated for testing purpose */
+#[allow(async_fn_in_trait)]
+async fn test(_arg1: &str) -> String {
+    todo!()
+}
+fn dyn_test<'_arg1, 'dynify>(
+    _arg1: &'_arg1 str,
+) -> ::dynify::r#priv::Fn<
+    (&'_arg1 str,),
+    dyn 'dynify + ::core::future::Future<Output = String>,
+>
+where
+    '_arg1: 'dynify,
+{
+    ::dynify::__from_fn!([] test, _arg1,)
+}
+fn main() {}

--- a/macros/src/dynify_tests/fn_returning_impl.rs
+++ b/macros/src/dynify_tests/fn_returning_impl.rs
@@ -1,0 +1,9 @@
+/* This file is @generated for testing purpose */
+#[allow(async_fn_in_trait)]
+fn test() -> impl core::any::Any {
+    todo!()
+}
+fn dyn_test<'dynify>() -> ::dynify::r#priv::Fn<(), dyn 'dynify + core::any::Any> {
+    ::dynify::__from_fn!([] test,)
+}
+fn main() {}

--- a/macros/src/lifetime.rs
+++ b/macros/src/lifetime.rs
@@ -5,7 +5,7 @@ use quote::format_ident;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::visit_mut::VisitMut;
-use syn::{parse_quote, parse_quote_spanned, visit_mut, FnArg, Ident, Lifetime, Result, Token};
+use syn::{parse_quote, parse_quote_spanned, visit_mut, FnArg, Ident, Lifetime, Result};
 
 pub(crate) struct TraitContext<'a> {
     pub generics: &'a syn::Generics,
@@ -210,7 +210,7 @@ impl visit_mut::VisitMut for LifetimeCollector<'_> {
 
 fn default_where_clause(where_clause: &mut Option<syn::WhereClause>) -> &mut syn::WhereClause {
     where_clause.get_or_insert_with(|| syn::WhereClause {
-        where_token: <Token![where]>::default(),
+        where_token: NewToken![where],
         predicates: Punctuated::new(),
     })
 }

--- a/macros/src/utils.rs
+++ b/macros/src/utils.rs
@@ -17,6 +17,10 @@ macro_rules! as_variant {
     };
 }
 
+macro_rules! NewToken {
+    ($($tt:tt)*) => (<::syn::Token![$($tt)*]>::default());
+}
+
 pub(crate) fn quote_with<F: Fn(&mut TokenStream)>(f: F) -> QuoteWith<F> {
     QuoteWith(f)
 }

--- a/tests/compile_fail/dynify_with_unknown_receiver.stderr
+++ b/tests/compile_fail/dynify_with_unknown_receiver.stderr
@@ -1,4 +1,4 @@
-error: cannot determine receiver type
+error: unsupported receiver type
  --> tests/compile_fail/dynify_with_unknown_receiver.rs:3:19
   |
 3 |     async fn test(self: MySelf);

--- a/tests/compile_fail/dynify_with_unsupported_item.rs
+++ b/tests/compile_fail/dynify_with_unsupported_item.rs
@@ -1,5 +1,8 @@
 #[dynify::dynify]
-fn test() {}
+fn test1() {}
+
+#[dynify::dynify]
+fn test2() -> FakeImpl {}
 
 #[dynify::dynify]
 opaque_trait!();

--- a/tests/compile_fail/dynify_with_unsupported_item.stderr
+++ b/tests/compile_fail/dynify_with_unsupported_item.stderr
@@ -1,11 +1,17 @@
-error: non-trait item is not supported yet
- --> tests/compile_fail/dynify_with_unsupported_item.rs:2:1
+error: input function must return an `impl` type
+ --> tests/compile_fail/dynify_with_unsupported_item.rs:2:4
   |
-2 | fn test() {}
-  | ^^^^^^^^^^^^
+2 | fn test1() {}
+  |    ^^^^^
 
-error: non-trait item is not supported yet
- --> tests/compile_fail/dynify_with_unsupported_item.rs:5:1
+error: input function must return an `impl` type
+ --> tests/compile_fail/dynify_with_unsupported_item.rs:5:4
   |
-5 | opaque_trait!();
+5 | fn test2() -> FakeImpl {}
+  |    ^^^^^
+
+error: expected a `fn` or `trait` item
+ --> tests/compile_fail/dynify_with_unsupported_item.rs:8:1
+  |
+8 | opaque_trait!();
   | ^^^^^^^^^^^^^^^^

--- a/tests/compile_pass/macro_example.rs
+++ b/tests/compile_pass/macro_example.rs
@@ -14,4 +14,9 @@ pub trait MyAsync<'x, T> {
     fn foo6<'a>(&self, s: &str) -> impl 'a + Send + std::any::Any;
 }
 
+#[dynify::dynify]
+pub async fn my_func(_id: &str) -> Vec<u8> {
+    todo!()
+}
+
 fn main() {}


### PR DESCRIPTION
 Support using `#[dynify]` on a standalone function:

```rust
#[dynify::dynify]
async fn my_func(id: usize) -> String {
    todo!()
}
// It expands to
fn dyn_my_func<'dynify>(
    id: usize,
) -> dynify::Fn!(usize => dyn 'dynify + Future<Output = String>) {
    dynify::from_fn!(my_func, id)
}


```