### PR TITLE
fix(macros): respect visibility of input function

### DIFF
--- a/macros/src/dynify.rs
+++ b/macros/src/dynify.rs
@@ -98,7 +98,12 @@ fn expand_trait(rename: Option<Ident>, mut dyn_trait: syn::ItemTrait) -> Result<
 }
 
 fn expand_fn(rename: Option<Ident>, mut dyn_fn: syn::ItemFn) -> Result<TokenStream> {
-    let syn::ItemFn { sig, attrs, .. } = &mut dyn_fn;
+    let syn::ItemFn {
+        vis,
+        sig,
+        attrs,
+        block: _,
+    } = &mut dyn_fn;
 
     let dyn_fn_name = rename.unwrap_or_else(|| format_ident!("dyn_{}", sig.ident));
     let input_fn_name = std::mem::replace(&mut sig.ident, dyn_fn_name);
@@ -107,7 +112,7 @@ fn expand_fn(rename: Option<Ident>, mut dyn_fn: syn::ItemFn) -> Result<TokenStre
     let attrs_outer = attrs.outer();
     let attrs_inner = attrs.inner();
     let impl_body = quote_transformed_body(transformed, &input_fn_name, sig);
-    Ok(quote!(#(#attrs_outer)* #sig { #(#attrs_inner)* #impl_body }))
+    Ok(quote!(#(#attrs_outer)* #vis #sig { #(#attrs_inner)* #impl_body }))
 }
 
 /// Generates implementation body for a transformed function.

--- a/macros/src/dynify_tests.rs
+++ b/macros/src/dynify_tests.rs
@@ -80,6 +80,10 @@ define_macro_tests!(
         quote!(trait Trait { async fn test(&self); }),
     )]
     // == Functions == //
+    #[case::fn_with_vis(
+        quote!(),
+        quote!(pub(crate) fn test() -> impl core::any::Any { todo!() }),
+    )]
     #[case::fn_returning_impl(
         quote!(),
         quote!(fn test() -> impl core::any::Any { todo!() }),

--- a/macros/src/dynify_tests/fn_with_vis.rs
+++ b/macros/src/dynify_tests/fn_with_vis.rs
@@ -1,0 +1,12 @@
+/* This file is @generated for testing purpose */
+#[allow(async_fn_in_trait)]
+pub(crate) fn test() -> impl core::any::Any {
+    todo!()
+}
+pub(crate) fn dyn_test<'dynify>() -> ::dynify::r#priv::Fn<
+    (),
+    dyn 'dynify + core::any::Any,
+> {
+    ::dynify::__from_fn!([] test,)
+}
+fn main() {}


### PR DESCRIPTION
The visibility of input functions is silently ignored, but should be prepended to `#[dynify]`ed functions.