### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ defining async methods that have multiple lifetimes in their signatures.
 - Support downcasting a `Buffered` pointer ([#10]).
 - Support unwrapping a `Buffered` pointer ([#11]).
 - Add a helper macro `#[dynify]` for trait transformations ([#12]).
-- Support transformations of function items for `#[dynify]` ([#13])
+- Support transformations of function items for `#[dynify]` ([#13]).
 
 [#10]: https://github.com/loichyan/dynify/pull/10
 [#11]: https://github.com/loichyan/dynify/pull/11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ## [Unreleased]
 
+## [0.1.1] - {{DATE}}
+
 ### Added
 
 - Support downcasting a `Buffered` pointer ([#10]).
@@ -86,4 +88,5 @@ details.
 
 [0.0.1]: https://github.com/loichyan/dynify/releases/tag/v0.0.1
 [0.1.0]: https://github.com/loichyan/dynify/releases/tag/v0.1.0
-[Unreleased]: https://github.com/loichyan/dynify/compare/v0.1.0..HEAD
+[0.1.1]: https://github.com/loichyan/dynify/releases/tag/v0.1.1
+[Unreleased]: https://github.com/loichyan/dynify/compare/v0.1.1..HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ## [0.1.1] - {{DATE}}
 
+The major update since the previous release is the introduction of the
+`#[dynify]` macro, which can significantly reduce boilerplate codes when
+defining async traits with methods that have multiple lifetimes in their
+signatures.
+
 ### Added
 
 - Support downcasting a `Buffered` pointer ([#10]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,15 +41,14 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 The major update since the previous release is the introduction of the
 `#[dynify]` macro, which can significantly reduce boilerplate codes when
-defining async traits with methods that have multiple lifetimes in their
-signatures.
+defining async methods that have multiple lifetimes in their signatures.
 
 ### Added
 
 - Support downcasting a `Buffered` pointer ([#10]).
 - Support unwrapping a `Buffered` pointer ([#11]).
 - Add a helper macro `#[dynify]` for trait transformations ([#12]).
-- Support transformation of a function for `#[dynify]` ([#13])
+- Support transformations of function items for `#[dynify]` ([#13])
 
 [#10]: https://github.com/loichyan/dynify/pull/10
 [#11]: https://github.com/loichyan/dynify/pull/11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ## [Unreleased]
 
-## [0.1.1] - {{DATE}}
+## [0.1.1] - 2025-08-28
 
 The major update since the previous release is the introduction of the
 `#[dynify]` macro, which can significantly reduce boilerplate codes when

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dynify"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dynify-macros",
  "fastrand",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "dynify-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fastrand",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["macros"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Loi Chyan <loichyan@foxmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ in stable Rust, along with a set of safe APIs for creating in-place constructors
 to initialize trait objects. Here’s a quick example of how to use dynify:
 
 ```rust
-use dynify::{from_fn, Dynify, Fn};
+use dynify::Dynify;;
 use std::future::Future;
 use std::mem::MaybeUninit;
 

--- a/src/dynify.md
+++ b/src/dynify.md
@@ -124,7 +124,7 @@ illustrated below, you can combine `#[dynify]` with
 // no longer specify a name in `#[dynify]` because `#[trait_variant::make]`
 // will generate two traits, which leads to conflicting trait definitions.
 #[trait_variant::make(Send)]
-#[dynify::dynify]
+#[dynify::dynify] // must be put within the scope of `#[trait_variant::make]`
 trait Client {
     async fn request(&self, uri: &str) -> String;
 }


### PR DESCRIPTION
The major update since the previous release is the introduction of the `#[dynify]` macro, which can significantly reduce boilerplate codes when defining async methods that have multiple lifetimes in their signatures.

### Added

- Support downcasting a `Buffered` pointer ([#10]).
- Support unwrapping a `Buffered` pointer ([#11]).
- Add a helper macro `#[dynify]` for trait transformations ([#12]).
- Support transformations of function items for `#[dynify]` ([#13])

[#10]: https://github.com/loichyan/dynify/pull/10
[#11]: https://github.com/loichyan/dynify/pull/11
[#12]: https://github.com/loichyan/dynify/pull/12
[#13]: https://github.com/loichyan/dynify/pull/13
