### PR TITLE
feat(macros): support using `#[dynify]` on remote items

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -8,3 +8,4 @@ coverage:
       default:
         enabled: true
         threshold: 1%
+    patch: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ## [Unreleased]
 
+### Added
+
+- Support using `#[dynify]` on remote items ([#{{PRNUM}}])
+
+[#{{PRNUM}}]: https://github.com/loichyan/dynify/pull/{{PRNUM}}
+
 ## [0.1.1] - 2025-08-28
 
 The major update since the previous release is the introduction of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,9 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ### Added
 
-- Support using `#[dynify]` on remote items ([#{{PRNUM}}])
+- Support using `#[dynify]` on remote items ([#17])
 
-[#{{PRNUM}}]: https://github.com/loichyan/dynify/pull/{{PRNUM}}
+[#17]: https://github.com/loichyan/dynify/pull/17
 
 ## [0.1.1] - 2025-08-28
 

--- a/macros/src/dynify.rs
+++ b/macros/src/dynify.rs
@@ -18,11 +18,7 @@ pub fn expand(attr: TokenStream, input: TokenStream) -> Result<TokenStream> {
             ))
         },
     };
-    Ok(quote!(
-        #[allow(async_fn_in_trait)]
-        #input
-        #output
-    ))
+    Ok(quote!(#input #output))
 }
 
 fn expand_trait(rename: Option<Ident>, mut dyn_trait: syn::ItemTrait) -> Result<TokenStream> {

--- a/macros/src/dynify.rs
+++ b/macros/src/dynify.rs
@@ -295,6 +295,8 @@ impl syn::parse::Parse for Options {
             remote: None,
         };
 
+        // The syntax for specifying arbitrary tokens as the value of an option
+        // follows those used in [serde](https://github.com/serde-rs/serde).
         if input.peek2(Token![=]) {
             let remote_token = input.parse::<remote>()?;
             let _eq_token = input.parse::<Token![=]>()?;

--- a/macros/src/dynify_tests.rs
+++ b/macros/src/dynify_tests.rs
@@ -96,6 +96,15 @@ define_macro_tests!(
         quote!(my_dyn_test),
         quote!(async fn test(_arg1: &str) -> String { todo!() }),
     )]
+    // == Remote items == //
+    #[case::remote_trait(
+        quote!(remote = "dynify::r#priv::TestRemoteTrait"),
+        quote!(trait DynTestRemoteTrait { async fn test(&self, arg: &str) -> usize; }),
+    )]
+    #[case::remote_fn(
+        quote!(remote = "dynify::r#priv::test_remote_fn"),
+        quote!(async fn dyn_test_remote_fn(_arg1: &str) -> usize {}),
+    )]
     fn ui(#[case] test_name: &str, #[case] attr: TokenStream, #[case] input: TokenStream) {
         let output = expand(attr, input).unwrap();
         // Append `fn main() {}` so that they can pass compile tests

--- a/macros/src/dynify_tests/fn_renamed.rs
+++ b/macros/src/dynify_tests/fn_renamed.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 async fn test(_arg1: &str) -> String {
     todo!()
 }

--- a/macros/src/dynify_tests/fn_returning_async.rs
+++ b/macros/src/dynify_tests/fn_returning_async.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 async fn test(_arg1: &str) -> String {
     todo!()
 }

--- a/macros/src/dynify_tests/fn_returning_impl.rs
+++ b/macros/src/dynify_tests/fn_returning_impl.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 fn test() -> impl core::any::Any {
     todo!()
 }

--- a/macros/src/dynify_tests/fn_with_vis.rs
+++ b/macros/src/dynify_tests/fn_with_vis.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 pub(crate) fn test() -> impl core::any::Any {
     todo!()
 }

--- a/macros/src/dynify_tests/remote_fn.rs
+++ b/macros/src/dynify_tests/remote_fn.rs
@@ -1,0 +1,13 @@
+/* This file is @generated for testing purpose */
+fn dyn_test_remote_fn<'_arg1, 'dynify>(
+    _arg1: &'_arg1 str,
+) -> ::dynify::r#priv::Fn<
+    (&'_arg1 str,),
+    dyn 'dynify + ::core::future::Future<Output = usize>,
+>
+where
+    '_arg1: 'dynify,
+{
+    ::dynify::__from_fn!([] dynify::r#priv::test_remote_fn, _arg1,)
+}
+fn main() {}

--- a/macros/src/dynify_tests/remote_trait.rs
+++ b/macros/src/dynify_tests/remote_trait.rs
@@ -1,0 +1,35 @@
+/* This file is @generated for testing purpose */
+#[allow(async_fn_in_trait)]
+#[allow(clippy::type_complexity)]
+trait DynTestRemoteTrait {
+    fn test<'this, 'arg, 'dynify>(
+        &'this self,
+        arg: &'arg str,
+    ) -> ::dynify::r#priv::Fn<
+        (::dynify::r#priv::RefSelf, &'arg str),
+        dyn 'dynify + ::core::future::Future<Output = usize>,
+    >
+    where
+        'this: 'dynify,
+        'arg: 'dynify,
+        Self: 'dynify;
+}
+#[allow(clippy::type_complexity)]
+impl<TestRemoteTraitImplementor: dynify::r#priv::TestRemoteTrait> DynTestRemoteTrait
+for TestRemoteTraitImplementor {
+    fn test<'this, 'arg, 'dynify>(
+        &'this self,
+        arg: &'arg str,
+    ) -> ::dynify::r#priv::Fn<
+        (::dynify::r#priv::RefSelf, &'arg str),
+        dyn 'dynify + ::core::future::Future<Output = usize>,
+    >
+    where
+        'this: 'dynify,
+        'arg: 'dynify,
+        Self: 'dynify,
+    {
+        ::dynify::__from_fn!([self] TestRemoteTraitImplementor::test, self, arg,)
+    }
+}
+fn main() {}

--- a/macros/src/dynify_tests/trait_async_fn.rs
+++ b/macros/src/dynify_tests/trait_async_fn.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 trait Trait {
     async fn test(this: &Self, arg: &str);
 }

--- a/macros/src/dynify_tests/trait_async_method.rs
+++ b/macros/src/dynify_tests/trait_async_method.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 trait Trait {
     async fn test(&self, arg: &str);
 }

--- a/macros/src/dynify_tests/trait_const_item.rs
+++ b/macros/src/dynify_tests/trait_const_item.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 trait Trait {
     const KST: usize;
 }

--- a/macros/src/dynify_tests/trait_empty.rs
+++ b/macros/src/dynify_tests/trait_empty.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 trait Trait {}
 #[allow(async_fn_in_trait)]
 #[allow(clippy::type_complexity)]

--- a/macros/src/dynify_tests/trait_impl_fn.rs
+++ b/macros/src/dynify_tests/trait_impl_fn.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 trait Trait {
     fn test(this: &Self, arg: &str) -> impl std::any::Any;
 }

--- a/macros/src/dynify_tests/trait_impl_method.rs
+++ b/macros/src/dynify_tests/trait_impl_method.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 trait Trait {
     fn test(&self, arg: &str) -> impl std::any::Any;
 }

--- a/macros/src/dynify_tests/trait_multi_items.rs
+++ b/macros/src/dynify_tests/trait_multi_items.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 trait Trait {
     const KST1: usize;
     const KST2: bool;

--- a/macros/src/dynify_tests/trait_regular_fn.rs
+++ b/macros/src/dynify_tests/trait_regular_fn.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 trait Trait {
     fn test(this: &Self, arg: &str);
 }

--- a/macros/src/dynify_tests/trait_type_item.rs
+++ b/macros/src/dynify_tests/trait_type_item.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 trait Trait {
     type Type: 'static;
 }

--- a/macros/src/dynify_tests/trait_with_generics.rs
+++ b/macros/src/dynify_tests/trait_with_generics.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 trait Trait<'life1, 'life2, Arg1, Arg2> {
     const KST: usize;
     type Type: 'static;

--- a/macros/src/dynify_tests/trait_with_name.rs
+++ b/macros/src/dynify_tests/trait_with_name.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 trait Trait {
     async fn test(&self);
 }

--- a/macros/src/dynify_tests/trait_with_where_clause.rs
+++ b/macros/src/dynify_tests/trait_with_where_clause.rs
@@ -1,5 +1,4 @@
 /* This file is @generated for testing purpose */
-#[allow(async_fn_in_trait)]
 trait Trait<'life1, 'life2>
 where
     'life2: 'life1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,16 @@ pub mod r#priv {
     pub type PinRcSelf = crate::receiver::Pin<RcSelf>;
     #[cfg(feature = "alloc")]
     pub type PinArcSelf = crate::receiver::Pin<ArcSelf>;
+
+    #[allow(unused)]
+    pub async fn test_remote_fn(arg1: &str) -> usize {
+        todo!()
+    }
+
+    #[allow(async_fn_in_trait)]
+    pub trait TestRemoteTrait {
+        async fn test(&self, arg1: &str) -> usize;
+    }
 }
 
 #[doc = include_str!("../README.md")]

--- a/tests/compile_pass/macro_example.rs
+++ b/tests/compile_pass/macro_example.rs
@@ -1,4 +1,5 @@
 #[dynify::dynify]
+#[allow(async_fn_in_trait)]
 pub trait MyAsync<'x, T> {
     type A<'a, B: 'a, C: 'a>
     where


### PR DESCRIPTION
Support using `#[dynify]` on remote items (either a trait or a function):

```rust
#[dynify(remote = "external_crate::Read")]
pub(crate) trait DynRead {
    async fn read_to_string(&mut self) -> String;
}
```

Note that the syntax for specifying arbitrary tokens as the value of an option of `#[dynify]` follows those used in [serde](https://github.com/serde-rs/serde).