### PR TITLE
fix: add `Send` and `Sync` bounds for `Buffered`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,9 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ### Fixed
 
-- Add `Send` and `Sync` bounds for `Buffered` ([#{{PRNUM}}])
+- Add `Send` and `Sync` bounds for `Buffered` ([#18])
 
-[#{{PRNUM}}]: https://github.com/loichyan/dynify/pull/{{PRNUM}}
+[#18]: https://github.com/loichyan/dynify/pull/18
 
 ## [0.1.1] - 2025-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 [#17]: https://github.com/loichyan/dynify/pull/17
 
+### Fixed
+
+- Add `Send` and `Sync` bounds for `Buffered` ([#{{PRNUM}}])
+
+[#{{PRNUM}}]: https://github.com/loichyan/dynify/pull/{{PRNUM}}
+
 ## [0.1.1] - 2025-08-28
 
 The major update since the previous release is the introduction of the

--- a/src/container_tests.rs
+++ b/src/container_tests.rs
@@ -121,6 +121,24 @@ fn unpin_buffered() {
 }
 
 #[test]
+fn send_buffered() {
+    let mut stack = newstk::<16>();
+    let init = from_closure(|slot| slot.write(123));
+    let val: Buffered<usize> = init.init(&mut stack);
+    fn ensure_send(_: impl Send) {}
+    ensure_send(val);
+}
+
+#[test]
+fn sync_buffered() {
+    let mut stack = newstk::<16>();
+    let init = from_closure(|slot| slot.write(123));
+    let val: Buffered<usize> = init.init(&mut stack);
+    fn ensure_sync(_: impl Sync) {}
+    ensure_sync(val);
+}
+
+#[test]
 fn project_buffered() {
     let mut stack = newstk::<16>();
     let init = from_closure(|slot| slot.write(PhantomPinned));


### PR DESCRIPTION
Add `Send` and `Sync` bounds for `Buffered` so that it can be used in multi-thread contexts.

Thanks for the feedback from [r/swoorup](https://www.reddit.com/r/rust/comments/1n36f4h/comment/nbz5ii0).