### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,9 +37,9 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ## [Unreleased]
 
-## [0.1.2] - {{DATE}}
+## [0.1.2] - 2025-09-07
 
-## [0.1.2] - {{DATE}}
+## [0.1.2] - 2025-09-07
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,6 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ## [0.1.2] - 2025-09-07
 
-## [0.1.2] - 2025-09-07
-
 ### Added
 
 - Support using `#[dynify]` on remote items ([#17]). This makes it more

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,16 +37,21 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ## [Unreleased]
 
+## [0.1.2] - {{DATE}}
+
+## [0.1.2] - {{DATE}}
+
 ### Added
 
-- Support using `#[dynify]` on remote items ([#17])
-
-[#17]: https://github.com/loichyan/dynify/pull/17
+- Support for using `#[dynify]` on remote items ([#17]). This makes it
+  convenient to work with foreign async traits.
 
 ### Fixed
 
-- Add `Send` and `Sync` bounds for `Buffered` ([#18])
+- Added `Send` and `Sync` bounds for `Buffered` ([#18]). This is crucial for
+  dynify to function in multi-threaded contexts.
 
+[#17]: https://github.com/loichyan/dynify/pull/17
 [#18]: https://github.com/loichyan/dynify/pull/18
 
 ## [0.1.1] - 2025-08-28
@@ -105,4 +110,5 @@ details.
 [0.0.1]: https://github.com/loichyan/dynify/tree/v0.0.1
 [0.1.0]: https://github.com/loichyan/dynify/compare/v0.0.1..v0.1.0
 [0.1.1]: https://github.com/loichyan/dynify/compare/v0.1.0..v0.1.1
-[Unreleased]: https://github.com/loichyan/dynify/compare/v0.1.1..HEAD
+[0.1.2]: https://github.com/loichyan/dynify/compare/v0.1.1..v0.1.2
+[Unreleased]: https://github.com/loichyan/dynify/compare/v0.1.2..HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ### Added
 
-- Support for using `#[dynify]` on remote items ([#17]). This makes it
+- Support using `#[dynify]` on remote items ([#17]). This makes it more
   convenient to work with foreign async traits.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ follows <https://www.conventionalcommits.org/en/v1.0.0/> to track changes.
 
 ### Fixed
 
-- Added `Send` and `Sync` bounds for `Buffered` ([#18]). This is crucial for
+- Add `Send` and `Sync` bounds for `Buffered` ([#18]). This is crucial for
   dynify to function in multi-threaded contexts.
 
 [#17]: https://github.com/loichyan/dynify/pull/17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dynify"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dynify-macros",
  "fastrand",
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "dynify-macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "fastrand",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["macros"]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Loi Chyan <loichyan@foxmail.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"
@@ -10,6 +10,7 @@ rust-version = "1.80"
 repository = "https://github.com/loichyan/dynify"
 
 [workspace.dependencies]
+dynify-macros = { path = "macros", version = "=0.1.2" }
 fastrand = "2.3.0"
 rstest = { version = "0.25.0", default-features = false }
 
@@ -41,7 +42,7 @@ macros = ["dep:dynify-macros"]
 smallvec = ["dep:smallvec"]
 
 [dependencies]
-dynify-macros = { path = "./macros", optional = true }
+dynify-macros = { workspace = true, optional = true }
 smallvec = { version = "1", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
### Added

- Support using `#[dynify]` on remote items ([#17]). This makes it more convenient to work with foreign async traits.

### Fixed

- Add `Send` and `Sync` bounds for `Buffered` ([#18]). This is crucial for dynify to function in multi-threaded contexts.

[#17]: https://github.com/loichyan/dynify/pull/17
[#18]: https://github.com/loichyan/dynify/pull/18
